### PR TITLE
faker is needed for the test_generator_faker tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,4 @@ license-files = []
 
 [tool.setuptools.dynamic]
 version = {attr = "etl_forge.__version__"} 
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "coverage>=6.0",
     "sphinx>=4.0.0",
     "sphinx-rtd-theme>=1.0.0",
+    "faker>=15.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
https://github.com/openjournals/joss-reviews/issues/9326

Another option is to skip these tests if faker isn't installed.